### PR TITLE
Add homepage pagination and backend support

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,7 +6,7 @@ import { client } from "@/lib/api/orpc";
 import { siteConfig } from "@/lib/site-config";
 
 export default async function Home() {
-  const skills = await client.skills.list();
+  const initialSkills = await client.skills.list({ page: 1 });
 
   return (
     <div className="min-h-screen bg-background">
@@ -33,7 +33,7 @@ export default async function Home() {
                   <span className="relative inline-flex h-2 w-2 rounded-full bg-primary"></span>
                 </span>
                 <span className="text-muted-foreground">
-                  {skills.length} Skills Available
+                  {initialSkills.total} Skills Available
                 </span>
               </div>
 
@@ -50,7 +50,7 @@ export default async function Home() {
         </div>
       </div>
 
-      <SkillsExplorer initialSkills={skills} />
+      <SkillsExplorer initialPage={initialSkills} />
 
       <section className="relative border-y border-border/60 bg-muted/40 shadow-[inset_0_1px_0_rgba(255,255,255,0.04)]">
         <FaqSection />

--- a/components/skills-explorer.tsx
+++ b/components/skills-explorer.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 import {
   InputGroup,
   InputGroupAddon,
@@ -9,42 +10,67 @@ import {
 } from "@/components/ui/input-group";
 import { Tabs, TabsContent } from "@/components/ui/tabs";
 import { orpc } from "@/lib/api/orpc";
-import { Skill } from "@/lib/types";
+import { PaginatedSkills } from "@/lib/types";
 import { useQuery } from "@tanstack/react-query";
-import { ArrowRight, Loader2, Search, X } from "lucide-react";
+import { ArrowLeft, ArrowRight, Loader2, Search, X } from "lucide-react";
 import Link from "next/link";
-import { debounce, parseAsString, useQueryState } from "nuqs";
-import { useEffect, useMemo, useState } from "react";
+import { debounce, parseAsInteger, parseAsString, useQueryState } from "nuqs";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 type SkillsExplorerProps = {
-  initialSkills: Skill[];
+  initialPage: PaginatedSkills;
 };
 
-export function SkillsExplorer({ initialSkills }: SkillsExplorerProps) {
+const PER_PAGE = 12;
+
+export function SkillsExplorer({ initialPage }: SkillsExplorerProps) {
   const [urlQuery, setUrlQuery] = useQueryState("q", {
     ...parseAsString.withDefault(""),
     history: "replace",
     limitUrlUpdates: debounce(300),
   });
+  const [page, setPage] = useQueryState("page", {
+    ...parseAsInteger.withDefault(1),
+    history: "replace",
+  });
 
-  const [activeCategory, setActiveCategory] = useState("All");
+  const [selectedCategory, setSelectedCategory] = useState("All");
   const activeQuery = urlQuery.trim();
+  const previousQueryRef = useRef(activeQuery);
 
-  const searchQuery = useQuery<Skill[]>(
-    activeQuery
-      ? orpc.skills.search.queryOptions({
-          input: { query: activeQuery },
-          placeholderData: initialSkills,
-          staleTime: 30_000,
-        })
-      : orpc.skills.search.queryOptions({
-          input: { query: "" },
-          initialData: initialSkills,
-          staleTime: 30_000,
-        })
+  const queryOptions = orpc.skills.search.queryOptions({
+    input: { query: activeQuery, page, perPage: PER_PAGE },
+  });
+
+  const searchQuery = useQuery<PaginatedSkills>({
+    ...queryOptions,
+    initialData:
+      activeQuery === "" && page === initialPage.page ? initialPage : undefined,
+    placeholderData: (previousData) => previousData ?? initialPage,
+    staleTime: 30_000,
+  });
+
+  const skills = useMemo(
+    () => searchQuery.data?.items ?? [],
+    [searchQuery.data]
   );
 
-  const skills = searchQuery.data ?? [];
+  useEffect(() => {
+    if (previousQueryRef.current !== activeQuery) {
+      previousQueryRef.current = activeQuery;
+      void setPage(1);
+    }
+  }, [activeQuery, setPage]);
+
+  useEffect(() => {
+    const resolvedPage = searchQuery.data?.page;
+    if (resolvedPage && resolvedPage !== page) {
+      void setPage(resolvedPage);
+    }
+  }, [page, searchQuery.data, setPage]);
+
+  const total = searchQuery.data?.total ?? 0;
+  const totalPages = searchQuery.data?.totalPages ?? 1;
 
   const categories = useMemo(() => {
     const unique = new Set(
@@ -53,11 +79,10 @@ export function SkillsExplorer({ initialSkills }: SkillsExplorerProps) {
     return ["All", ...Array.from(unique)];
   }, [skills]);
 
-  useEffect(() => {
-    if (!categories.includes(activeCategory)) {
-      setActiveCategory("All");
-    }
-  }, [activeCategory, categories]);
+  const activeCategory = useMemo(
+    () => (categories.includes(selectedCategory) ? selectedCategory : "All"),
+    [categories, selectedCategory]
+  );
 
   return (
     <>
@@ -68,7 +93,10 @@ export function SkillsExplorer({ initialSkills }: SkillsExplorerProps) {
           </InputGroupAddon>
           <InputGroupInput
             aria-label="Search skills"
-            onChange={(event) => void setUrlQuery(event.target.value)}
+            onChange={(event) => {
+              void setUrlQuery(event.target.value);
+              void setPage(1);
+            }}
             placeholder="Search skills..."
             value={urlQuery}
           />
@@ -79,7 +107,10 @@ export function SkillsExplorer({ initialSkills }: SkillsExplorerProps) {
               ) : (
                 <InputGroupButton
                   aria-label="Clear search"
-                  onClick={() => void setUrlQuery("")}
+                  onClick={() => {
+                    void setUrlQuery("");
+                    void setPage(1);
+                  }}
                   size="icon-sm"
                   variant="ghost"
                 >
@@ -94,7 +125,7 @@ export function SkillsExplorer({ initialSkills }: SkillsExplorerProps) {
       <main className="mx-auto container px-6 pt-10 pb-16">
         <Tabs
           value={activeCategory}
-          onValueChange={setActiveCategory}
+          onValueChange={setSelectedCategory}
           className="w-full"
         >
           {/* <div className="mb-12 flex flex-col gap-4">
@@ -116,76 +147,173 @@ export function SkillsExplorer({ initialSkills }: SkillsExplorerProps) {
 
           {categories.map((category) => (
             <TabsContent key={category} value={category} className="mt-0">
-              <div className="grid auto-rows-[280px] gap-6 sm:grid-cols-2 lg:grid-cols-3">
-                {skills
-                  .filter(
-                    (skill) => category === "All" || skill.category === category
-                  )
-                  .map((skill, index) => (
-                    <Link
-                      key={skill.id}
-                      className="group block h-full"
-                      href={`/skills/${skill.id}`}
-                      style={{ animationDelay: `${index * 50}ms` }}
-                    >
-                      <Card className="relative h-full overflow-hidden border border-border/40 bg-card/50 p-6 backdrop-blur-sm transition-all hover:border-border hover:bg-card hover:shadow-lg hover:shadow-primary/5 animate-fade-in-up">
-                        <div className="mb-4">
-                          <h3 className="mb-2 text-xl font-semibold text-foreground transition-colors group-hover:text-primary">
-                            {skill.name}
-                          </h3>
-                          <p className="text-sm text-muted-foreground line-clamp-6">
-                            {skill.description}
-                          </p>
-                        </div>
-
-                        {skill.tags.length > 0 && (
-                          <div className="mb-4 flex flex-wrap gap-2">
-                            {skill.tags.map((tag: string) => (
-                              <span
-                                key={tag}
-                                className="inline-flex items-center rounded-md border border-border/40 bg-muted/30 px-2 py-0.5 text-xs font-medium text-muted-foreground"
-                              >
-                                {tag}
-                              </span>
-                            ))}
-                          </div>
-                        )}
-
-                        <div className="mt-auto flex items-center justify-between gap-4 border-t border-border/40 pt-4">
-                          {skill.authorName ? (
-                            <div className="flex items-center gap-3">
-                              {skill.authorAvatarUrl ? (
-                                <img
-                                  alt={skill.authorName}
-                                  className="h-8 w-8 rounded-full border border-border/60 object-cover"
-                                  src={skill.authorAvatarUrl}
-                                />
-                              ) : null}
-                              <div className="text-sm text-muted-foreground">
-                                <span className="font-medium text-foreground">
-                                  {skill.authorName}
-                                </span>
-                              </div>
+              {skills.filter(
+                (skill) => category === "All" || skill.category === category
+              ).length === 0 ? (
+                <div className="flex min-h-[200px] items-center justify-center rounded-xl border border-dashed border-border/50 bg-muted/30">
+                  <p className="text-sm text-muted-foreground">
+                    No skills found. Try adjusting your search.
+                  </p>
+                </div>
+              ) : (
+                <>
+                  <div className="grid auto-rows-[280px] gap-6 sm:grid-cols-2 lg:grid-cols-3">
+                    {skills
+                      .filter(
+                        (skill) =>
+                          category === "All" || skill.category === category
+                      )
+                      .map((skill, index) => (
+                        <Link
+                          key={skill.id}
+                          className="group block h-full"
+                          href={`/skills/${skill.id}`}
+                          style={{ animationDelay: `${index * 50}ms` }}
+                        >
+                          <Card className="relative h-full overflow-hidden border border-border/40 bg-card/50 p-6 backdrop-blur-sm transition-all hover:border-border hover:bg-card hover:shadow-lg hover:shadow-primary/5 animate-fade-in-up">
+                            <div className="mb-4">
+                              <h3 className="mb-2 text-xl font-semibold text-foreground transition-colors group-hover:text-primary">
+                                {skill.name}
+                              </h3>
+                              <p className="text-sm text-muted-foreground line-clamp-6">
+                                {skill.description}
+                              </p>
                             </div>
-                          ) : (
-                            <span className="text-sm text-muted-foreground">
-                              No author info
-                            </span>
-                          )}
-                          <span className={"flex items-center gap-2"}>
-                            View details <ArrowRight size="16" />
-                          </span>
-                        </div>
 
-                        <div className="absolute inset-0 -z-10 bg-linear-to-br from-primary/5 via-transparent to-transparent opacity-0 transition-opacity group-hover:opacity-100" />
-                      </Card>
-                    </Link>
-                  ))}
-              </div>
+                            {skill.tags.length > 0 && (
+                              <div className="mb-4 flex flex-wrap gap-2">
+                                {skill.tags.map((tag: string) => (
+                                  <span
+                                    key={tag}
+                                    className="inline-flex items-center rounded-md border border-border/40 bg-muted/30 px-2 py-0.5 text-xs font-medium text-muted-foreground"
+                                  >
+                                    {tag}
+                                  </span>
+                                ))}
+                              </div>
+                            )}
+
+                            <div className="mt-auto flex items-center justify-between gap-4 border-t border-border/40 pt-4">
+                              {skill.authorName ? (
+                                <div className="flex items-center gap-3">
+                                  {skill.authorAvatarUrl ? (
+                                    <img
+                                      alt={skill.authorName}
+                                      className="h-8 w-8 rounded-full border border-border/60 object-cover"
+                                      src={skill.authorAvatarUrl}
+                                    />
+                                  ) : null}
+                                  <div className="text-sm text-muted-foreground">
+                                    <span className="font-medium text-foreground">
+                                      {skill.authorName}
+                                    </span>
+                                  </div>
+                                </div>
+                              ) : (
+                                <span className="text-sm text-muted-foreground">
+                                  No author info
+                                </span>
+                              )}
+                              <span className={"flex items-center gap-2"}>
+                                View details <ArrowRight size="16" />
+                              </span>
+                            </div>
+
+                            <div className="absolute inset-0 -z-10 bg-linear-to-br from-primary/5 via-transparent to-transparent opacity-0 transition-opacity group-hover:opacity-100" />
+                          </Card>
+                        </Link>
+                      ))}
+                  </div>
+
+                  <div className="mt-8 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+                    <p className="text-sm text-muted-foreground">
+                      Showing{" "}
+                      <span className="font-medium text-foreground">
+                        {total === 0
+                          ? 0
+                          : Math.min((page - 1) * PER_PAGE + 1, total)}
+                      </span>{" "}
+                      to{" "}
+                      <span className="font-medium text-foreground">
+                        {total === 0 ? 0 : Math.min(page * PER_PAGE, total)}
+                      </span>{" "}
+                      of{" "}
+                      <span className="font-medium text-foreground">
+                        {total}
+                      </span>{" "}
+                      skills
+                    </p>
+
+                    <div className="flex items-center gap-2">
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => void setPage(Math.max(page - 1, 1))}
+                        disabled={page <= 1}
+                      >
+                        <ArrowLeft className="mr-2 h-4 w-4" />
+                        Previous
+                      </Button>
+                      <PaginationStatus
+                        page={page}
+                        totalPages={totalPages}
+                        onChangePage={(nextPage) => void setPage(nextPage)}
+                      />
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() =>
+                          void setPage(Math.min(page + 1, totalPages))
+                        }
+                        disabled={page >= totalPages}
+                      >
+                        Next
+                        <ArrowRight className="ml-2 h-4 w-4" />
+                      </Button>
+                    </div>
+                  </div>
+                </>
+              )}
             </TabsContent>
           ))}
         </Tabs>
       </main>
     </>
+  );
+}
+
+type PaginationStatusProps = {
+  page: number;
+  totalPages: number;
+  onChangePage: (page: number) => void;
+};
+
+function PaginationStatus({
+  page,
+  totalPages,
+  onChangePage,
+}: PaginationStatusProps) {
+  const windowSize = 3;
+  const start = Math.max(1, page - windowSize);
+  const end = Math.min(totalPages, page + windowSize);
+  const pages = [];
+
+  for (let i = start; i <= end; i += 1) {
+    pages.push(i);
+  }
+
+  return (
+    <div className="flex items-center gap-1">
+      {pages.map((pageNumber) => (
+        <Button
+          key={pageNumber}
+          variant={pageNumber === page ? "default" : "outline"}
+          size="icon-sm"
+          onClick={() => onChangePage(pageNumber)}
+        >
+          {pageNumber}
+        </Button>
+      ))}
+    </div>
   );
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,21 +1,22 @@
-import { client } from '@/lib/api/orpc'
-import type { InferClientOutputs } from '@orpc/client'
+import { client } from "@/lib/api/orpc";
+import type { InferClientOutputs } from "@orpc/client";
 
-type Outputs = InferClientOutputs<typeof client>
+type Outputs = InferClientOutputs<typeof client>;
 
-export type Skill = Outputs['skills']['list'][number]
+export type PaginatedSkills = Outputs["skills"]["list"];
+export type Skill = Outputs["skills"]["list"]["items"][number];
 
 export type SkillAuthor = {
-  name: string
-  url: string
-  avatarUrl: string
-}
+  name: string;
+  url: string;
+  avatarUrl: string;
+};
 
 export type ParsedSkill = {
-  id: string
-  name: string
-  description: string
-  category?: string
-  tags: string[]
-  author?: SkillAuthor
-}
+  id: string;
+  name: string;
+  description: string;
+  category?: string;
+  tags: string[];
+  author?: SkillAuthor;
+};


### PR DESCRIPTION
## Summary
- add paginated skills list/search endpoints with validated page and per-page handling
- wire the homepage skills explorer to nuqs-managed search/page params and render shadcn pagination controls
- surface total skill counts in the hero and reuse initial paginated data for SSR

## Testing
- pnpm lint (warnings about existing <img> usage and a preexisting hook dependency warning in skill-files-explorer)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b745ec23083219869754e8aae04d1)