### PR TITLE
fix: cap tag list height to preserve author area in skill cards

### DIFF
--- a/components/skills-explorer.tsx
+++ b/components/skills-explorer.tsx
@@ -167,7 +167,7 @@ export function SkillsExplorer({
                           </div>
 
                           {skill.tags.length > 0 && (
-                            <div className="mb-4 flex flex-wrap gap-2">
+                            <div className="mb-4 flex max-h-16 flex-wrap gap-2 overflow-hidden">
                               {skill.tags.map((tag: string) => (
                                 <span
                                   key={tag}


### PR DESCRIPTION
### Motivation
- Tags in skill cards can wrap and push the author row out of view, reducing readability and hiding author information.

### Description
- Limit the tag list container height to `max-h-16` and add `overflow-hidden` on the tag wrapper in `components/skills-explorer.tsx` so tags no longer push the author area off the card.
- This is a single small UI-only Tailwind class change to the tag container: `className="mb-4 flex max-h-16 flex-wrap gap-2 overflow-hidden"`.

### Testing
- Ran `pnpm format` (Prettier) which completed successfully. 
- Attempted a visual verification by launching the dev server and capturing a screenshot with Playwright, but the Playwright Chromium process failed to launch (SIGSEGV) so the screenshot step did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6968281bf97c832193cbb3e348a9170e)